### PR TITLE
Use dropdown in underground

### DIFF
--- a/src/components/gameMenu.html
+++ b/src/components/gameMenu.html
@@ -1,6 +1,6 @@
-<div class="dropdown clearfix" style="position:absolute; right:0; top:0; z-index: 100;">
-    <button class="btn btn-secondary dropdown-toggle float-right" type="button" data-toggle="dropdown">Start
-        Menu
+<div id="startMenu" class="dropdown clearfix" style="position:absolute; right:0; top:0; z-index: 100;">
+    <button class="btn btn-secondary dropdown-toggle float-right" type="button" data-toggle="dropdown">
+        Start Menu
         <span class="caret"></span>
     </button>
     <ul class="dropdown-menu dropdown-menu-right">

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -50,13 +50,6 @@ style="cursor:default" tabindex="-1">
                 </div>
                 <div id="treasures" class="tab-pane fade">
                     <div data-bind="if: player.hasMineItems()">
-                        <div class="d-flex justify-content-center sticky-top bg-white border-bottom m-0 p-0"
-                             data-bind="template: { name:'multiOptionTemplate',
-                                                    data: { observable: Underground.sellAmount,
-                                                            optionValues: [1,10,100,1000,Infinity]
-                                                          }
-                                                  }">
-                        </div>
                         <table class="table table-sm table-hover table-striped m-0">
                             <thead>
                                 <tr>
@@ -184,11 +177,25 @@ style="cursor:default" tabindex="-1">
             <td class='vertical-middle' data-bind='text: value + " " + UndergroundItem.getFullResourceName(valueType, value)'></td>
             <!-- /ko -->
             <td class='vertical-middle'>
-                <button class='btn btn-success btn-block'
-                        data-bind='click: function(){ Underground.sellMineItem(id, Underground.sellAmount()) },
-                                css: { disabled: amount() <= 0 || (valueType === "Mine Egg" && !App.game.breeding.hasFreeEggSlot()) },
-                                text: valueType === "Mine Egg" ? "Breed" : "Sell"'>
-                </button>
+                <div class="btn-group btn-block">
+                    <button class='btn btn-success btn-block' onclick="Underground.sellMineItem(this.dataset.itemid, +(this.nextElementSibling ? this.nextElementSibling.innerText : 1) || 1)"
+                            data-bind="attr: { 'data-itemid': id },
+                                    css: { disabled: amount() <= 0 || (valueType === 'Mine Egg' && !App.game.breeding.hasFreeEggSlot()) },
+                                    text: valueType === 'Mine Egg' ? 'Breed' : 'Sell'">
+                    </button>
+                    <!-- ko if: valueType !== 'Mine Egg' -->
+                    <button type="button" class="btn btn-success dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        1
+                    </button>
+                    <div class="dropdown-menu">
+                        <button class="dropdown-item" type="button" onclick="this.parentElement.previousElementSibling.innerText = this.innerText + ' '">1</button>
+                        <button class="dropdown-item" type="button" onclick="this.parentElement.previousElementSibling.innerText = this.innerText + ' '">10</button>
+                        <button class="dropdown-item" type="button" onclick="this.parentElement.previousElementSibling.innerText = this.innerText + ' '">100</button>
+                        <button class="dropdown-item" type="button" onclick="this.parentElement.previousElementSibling.innerText = this.innerText + ' '">1000</button>
+                        <button class="dropdown-item" type="button" onclick="this.parentElement.previousElementSibling.innerText = this.innerText + ' '">Infinity</button>
+                    </div>
+                    <!-- /ko -->
+                </div>
             </td>
         </tr>
     </script>

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -8,7 +8,6 @@ class Underground {
     private static _energy: KnockoutObservable<number> = ko.observable(0);
     public static upgradeList: Array<Upgrade> = [];
 
-    public static sellAmount: KnockoutObservable<number> = ko.observable(1);
     public static tradeAmount: KnockoutObservable<number> = ko.observable(1);
 
     public static getMaxEnergy() {

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -157,28 +157,18 @@ body:hover {
   cursor: default;
 }
 
-.dropdown-menu {
-  border: 1px solid black;
-}
+#startMenu {
+  .dropdown-menu {
+    border: 1px solid black;
+  }
 
-.page-item {
-  margin-bottom: 10px;
-  border: 1px solid;
-  border-radius: 2px;
-  border-color: transparent #7f7f7f #7f7f7f;
-}
+  .dropdown-item {
+    font-family: pokemonFont, "Helvetica Neue", sans-serif;
+  }
 
-.dropdown-item {
-  font-family: pokemonFont, "Helvetica Neue", sans-serif;
-}
-
-.dropdown-toggle {
-  font-family: pokemonFont, "Helvetica Neue", sans-serif;
-}
-
-.page-item .card {
-  border-radius: 0;
-  min-height: 40px;
+  .dropdown-toggle {
+    font-family: pokemonFont, "Helvetica Neue", sans-serif;
+  }
 }
 
 .card span {


### PR DESCRIPTION
Just making a PR in relation to https://github.com/pokeclicker-dev/pokeclicker/pull/55/.

The buttons up the top seem to not quite be fully self explanatory,
So i've moved it to be in a dropdown on the side of each sell button,
Not sure if this is the best way to go about it either though so i've only applied it to the item list, not the trade list:

![image](https://user-images.githubusercontent.com/7288322/89700709-8811cd80-d984-11ea-991a-cf4af7e4a252.png)

Not sure how I feel about the success class on the drop down too, but also not sure what else would go well with it.

